### PR TITLE
Fix per4m VizTracer runtime compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - importlib-metadata.patch
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - per4m = per4m.__main__:main
@@ -38,7 +38,7 @@ requirements:
     - numpy
     - python
     - tabulate
-    - viztracer
+    - viztracer <0.16
 
 test:
   imports:
@@ -49,6 +49,8 @@ test:
     - per4m --help
     - per4m perf2trace --help
     - perf-pyrecord --help
+    - perf-pyscript --help
+    - offgil --help
   requires:
     - python
     - pip

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,6 +1,18 @@
 import per4m
+import per4m.offgil
 import per4m.pytrace
+import per4m.script
 
 
 assert per4m.__version__ == "0.1.0"
 assert hasattr(per4m.pytrace, "start")
+
+per4m.pytrace.start()
+
+
+def traced_function(value):
+    return value + 1
+
+
+assert traced_function(41) == 42
+per4m.pytrace.stop()


### PR DESCRIPTION
## Summary
- constrain runtime `viztracer` to `<0.16`, the last range that still provides `viztracer.prog_snapshot` used by `per4m.script` and `per4m.offgil`
- bump the build number because runtime metadata changes
- strengthen package tests to import the affected modules, exercise the compiled `per4m.pytrace` start/stop path, and run `perf-pyscript --help` plus `offgil --help`

## Validation
- `git diff --check`
- `conda-smithy recipe-lint --conda-forge recipe`
- `pixi exec -s python=3.10 -s per4m=0.1.0 -s 'viztracer<0.16' python recipe/run_test.py`
- `pixi exec -s python=3.10 -s per4m=0.1.0 -s 'viztracer<0.16' perf-pyscript --help`
- `pixi exec -s python=3.10 -s per4m=0.1.0 -s 'viztracer<0.16' offgil --help`
- local Linux conda build/test: `conda build recipe -m .ci_support/linux_64_python3.10.____cpython.yaml -c conda-forge`